### PR TITLE
refactor: optimize chunking for better sheng context retrieval (Fixes #11)

### DIFF
--- a/ingest.py
+++ b/ingest.py
@@ -26,8 +26,8 @@ print(f"✅ Loaded {len(docs)} document pages")
 # Split documents
 print("✂️ Splitting documents into chunks...")
 text_splitter = RecursiveCharacterTextSplitter(
-    chunk_size=1200,
-    chunk_overlap=300,
+    chunk_size=1000,
+    chunk_overlap=200,
     length_function=len 
 )
 


### PR DESCRIPTION
Reducing chunk size to 1000 will help the model maintain focus on specific policy clauses without getting lost in long paragraphs.